### PR TITLE
Remove keyColumn instance variables

### DIFF
--- a/AcceptanceCriterion.js
+++ b/AcceptanceCriterion.js
@@ -4,7 +4,6 @@ class AcceptanceCriterion extends DatabaseTable {
     isAccepted = false;
     backlogItemID = undefined;
   
-    static keyColumn = 'ID';
     static columns = [
         'ID', 
         'Description', 

--- a/Action.js
+++ b/Action.js
@@ -1,8 +1,6 @@
 class Action extends DatabaseTable {
     name = '';
     extraChecksNeeded = false;
-
-    static keyColumn = 'Name';
     
     static columns = [
         'Name', 

--- a/Assignee.js
+++ b/Assignee.js
@@ -6,8 +6,6 @@ class Assignee extends DatabaseTable {
     emailAddress = '';
     color = undefined;
 
-    static keyColumn = 'ID';
-
     static columns = [
         'ID', 
         'FirstName', 

--- a/BLIChange.js
+++ b/BLIChange.js
@@ -4,9 +4,7 @@ class BLIChange extends DatabaseTable {
     stateName = undefined
     state = undefined;
     backlogItemID = undefined;
-
-    static keyColumn = 'ID';
-
+    
     static columns = [
         'ID', 
         'Date', 

--- a/BacklogItem.js
+++ b/BacklogItem.js
@@ -11,10 +11,8 @@ class BacklogItem extends DatabaseTable {
     acceptanceCriteria = new Map();
     parentBLI = undefined;
     children = new Map();
-
-    // history = new BLIChangeHistory;
-
-    static keyColumn = 'ID';
+    history = undefined;
+    
     static columns = [
         'ID', 
         'Priority',

--- a/CardLayout.js
+++ b/CardLayout.js
@@ -6,8 +6,6 @@ class CardLayout extends DatabaseTable {
 
     static lines = new Map();
 
-
-    static keyColumn = 'Numbers';
     static columns = [
         'Numbers', 
         'Name'

--- a/CardSort.js
+++ b/CardSort.js
@@ -5,8 +5,6 @@ class CardSort extends DatabaseTable {
     transitionStartStateName = undefined;
     transitionActionName = undefined;
 
-
-    static keyColumn = 'Name';
     static columns = [
         'Name', 
         'IsTransition', 

--- a/Database.js
+++ b/Database.js
@@ -4,7 +4,7 @@ class Database {
         var records = this.allRecordsFrom(aClass.getTableName());
         for (var eachRecord of records) {
             var instance = this.instantiateFrom(aClass, eachRecord);
-            var keyColumn = aClass.keyColumn;
+            var keyColumn = aClass.getKeyColumn();
             map.set(eachRecord.at(keyColumn), instance);
         }
         return map;

--- a/DatabaseTable.js
+++ b/DatabaseTable.js
@@ -1,7 +1,6 @@
 class DatabaseTable {
     static isLoaded = false;
     static columnFunctionMappings;
-    static keyColumn = '';
     static instances = undefined;
     static tableName = this.name;
     static columns = [];

--- a/GroupCriterion.js
+++ b/GroupCriterion.js
@@ -6,7 +6,6 @@ class GroupCriterion extends DatabaseTable {
     level = undefined;
     stateName = undefined;
 
-    static keyColumn = 'Name';
     static columns = [
         'Name', 
         'IsLevel', 

--- a/Level.js
+++ b/Level.js
@@ -3,7 +3,6 @@ class Level extends DatabaseTable {
     name = '';
     color = undefined;
 
-    static keyColumn = 'Number';
     static columns = [
         'Number', 
         'Name', 

--- a/Preference.js
+++ b/Preference.js
@@ -2,7 +2,6 @@ class Preference extends DatabaseTable {
     preferenceType = '';
     preference = undefined;
 
-    static keyColumn = 'PreferenceType';
     static columns = [
         'PreferenceType',
         'Preference'

--- a/Sprint.js
+++ b/Sprint.js
@@ -3,7 +3,6 @@ class Sprint extends DatabaseTable {
     startDate = undefined;
     duration = undefined;
 
-    static keyColumn = 'ID';
     static columns = [
         'ID',
         'StartDate', 

--- a/SprintToBLIMapping.js
+++ b/SprintToBLIMapping.js
@@ -3,7 +3,6 @@ class SprintToBLIMapping extends DatabaseTable {
     sprintID = undefined;
     backlogItemID = undefined;
 
-    static keyColumn = 'SprintToBLIMappingID';
     static columns = [
         'SprintToBLIMappingID',
         'SprintID', 

--- a/State.js
+++ b/State.js
@@ -5,7 +5,6 @@ class State extends DatabaseTable {
     includeInPipeline = false;
     includeInVelocity = false;
 
-    static keyColumn = 'Name';
     static columns = [
         'Name', 
         'Color', 

--- a/SystemConstant.js
+++ b/SystemConstant.js
@@ -2,7 +2,6 @@ class SystemConstant extends DatabaseTable {
     systemValueType = '';
     systemValue = undefined;
 
-    static keyColumn = 'SystemValueType';
     static columns = [
         'SystemValueType', 
         'SystemValue', 

--- a/Transition.js
+++ b/Transition.js
@@ -3,7 +3,6 @@ class Transition extends DatabaseTable {
     startPath = [];
     endState = '';
 
-    static keyColumn = 'StartPath';
     static columns = [
         'StartPath', 
         'EndState'


### PR DESCRIPTION
keyColumn instance variable is no longer needed in the database classes because it is derived in the DatabaseTable>>getKeyColumn method; defaults to whatever the first column name is in the array of column names.